### PR TITLE
Enable rendering from saved captures

### DIFF
--- a/ScanningObjectsUsingObjectCapture/GuidedCaptureSample/GuidedCaptureSample/AppDataModel.swift
+++ b/ScanningObjectsUsingObjectCapture/GuidedCaptureSample/GuidedCaptureSample/AppDataModel.swift
@@ -231,6 +231,16 @@ extension AppDataModel {
         state = .failed
     }
 
+    func startReconstruction(fromExistingFolder url: URL) {
+        do {
+            captureFolderManager = try CaptureFolderManager(existingFolder: url)
+            try startReconstruction()
+        } catch {
+            logger.error("Reconstructing failed!")
+            switchToErrorState(error: error)
+        }
+    }
+
     // Moves from prepareToReconstruct to .reconstructing.
     // Should be called from the ReconstructionPrimaryView async task once it is on the screen.
     private func startReconstruction() throws {

--- a/ScanningObjectsUsingObjectCapture/GuidedCaptureSample/GuidedCaptureSample/CaptureFolderManager.swift
+++ b/ScanningObjectsUsingObjectCapture/GuidedCaptureSample/GuidedCaptureSample/CaptureFolderManager.swift
@@ -58,6 +58,20 @@ class CaptureFolderManager {
         try CaptureFolderManager.createDirectoryRecursively(modelsFolder)
     }
 
+    init(existingFolder: URL) throws {
+        captureFolder = existingFolder
+        imagesFolder = existingFolder.appendingPathComponent(Self.imagesFolderName)
+        checkpointFolder = existingFolder.appendingPathComponent("Checkpoint/")
+        modelsFolder = existingFolder.appendingPathComponent("Models/")
+
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: imagesFolder.path, isDirectory: &isDir), isDir.boolValue,
+              FileManager.default.fileExists(atPath: checkpointFolder.path, isDirectory: &isDir), isDir.boolValue,
+              FileManager.default.fileExists(atPath: modelsFolder.path, isDirectory: &isDir) else {
+            throw Error.invalidShotUrl
+        }
+    }
+
     // - MARK: Private interface below.
 
     // Creates a new capture directory based on the current timestamp in the top level Documents
@@ -121,4 +135,11 @@ class CaptureFolderManager {
     // What is appended in front of the capture id to get a file basename.
     private static let imageStringPrefix = "IMG_"
     private static let heicImageExtension = "HEIC"
+}
+
+private extension URL {
+    /// Convenience accessor for the application's Documents directory.
+    static var documentsDirectory: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
 }

--- a/ScanningObjectsUsingObjectCapture/GuidedCaptureSample/GuidedCaptureSample/Views/OnboardingButtonView.swift
+++ b/ScanningObjectsUsingObjectCapture/GuidedCaptureSample/GuidedCaptureSample/Views/OnboardingButtonView.swift
@@ -70,6 +70,13 @@ struct OnboardingButtonView: View {
                                  shouldApplyBackground: shouldApplyBackground,
                                  showBusyIndicator: showBusyIndicator,
                                  action: { [weak session] in session?.finish() })
+
+                    // Allow saving the capture for later reconstruction when the user decides not to process now.
+                    CreateButton(buttonLabel: LocalizedString.saveDraft,
+                                 buttonLabelColor: .blue,
+                                 action: { [weak appModel] in
+                        appModel?.saveDraft()
+                    })
                 }
                 if currentStateInputs.contains(where: { $0 == .objectCannotBeFlipped }) {
                     CreateButton(buttonLabel: LocalizedString.cannotFlipYourObject,


### PR DESCRIPTION
## Summary
- allow saving a capture for processing later
- show saved captures even after a reset
- utility URL.documentsDirectory accessor

## Testing
- `swift --version`
